### PR TITLE
No spaces in key fingerprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@
     <p>Also used for zen's apt repo's
         <a href="https://horizenofficial.github.io/repo">HorizenOfficial</a>
     </p>
-    <h4>Key fingerprint=219F 5574 0BBF 7A1C E368 BA45 FB70 53CE 4991 B669</h4>
+    <h4>Key fingerprint=219F55740BBF7A1CE368BA45FB7053CE4991B669</h4>
     <hr/>
 
     <h2>Luigi @aklar</h2>
     <a href="keys/luigi.asc">luigi.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/A66C269C541AB17134A9B47D4A80E416439F3C82">0x4A80E416439F3C82</a>
-    <h4>Key fingerprint=A66C 269C 541A B171 34A9  B47D 4A80 E416 439F 3C82</h4>
+    <h4>Key fingerprint=A66C269C541AB17134A9B47D4A80E416439F3C82</h4>
     <hr/>
 
     <h2>Yuriko @yurikoinaba</h2>
@@ -55,7 +55,7 @@
     <h2>Andrea Carbone @acarbone</h2>
     <a href="keys/acarbone.asc">acarbone.asc</a>
     <a href="https://pgp.mit.edu/pks/lookup?op=get&search=0x2C346A3DA06D36FB">0x2C346A3DA06D36FB</a>
-    <h4>Key fingerprint=5F39 3C6E F5FC 5358 C492 3509 2C34 6A3D A06D 36FB</h4>
+    <h4>Key fingerprint=5F393C6EF5FC5358C49235092C346A3DA06D36FB</h4>
     <hr/>
 
     <h2>TonyBo Bello @devopsbo3</h2>
@@ -97,7 +97,7 @@
     <h2>Yuri Sibirski @ysibirski</h2>
     <a href="keys/ysibirski.asc">ysibirski.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/BD3D90430CA0D3C3FF3BE7C13122C53D2BCBC536">0x3122C53D2BCBC536</a>
-    <h4>Key fingerprint=BD3D 9043 0CA0 D3C3 FF3B E7C1 3122 C53D 2BCB C536</h4>
+    <h4>Key fingerprint=BD3D90430CA0D3C3FF3BE7C13122C53D2BCBC536</h4>
     <hr/>
 
     <h2>Davide Banfi @davehorizen</h2>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <p><You may use the following to encrypt sensitive emails:/p>
     <a href="keys/security.asc">security[at]horizen.global</a>
     <a href="https://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0x4D20583410704F2E">0x4D20583410704F2E</a>
-    <h4>Key fingerprint=5C6B F592 88CD D4EC A456  6F99 4D20 5834 1070 4F2E</h4>
+    <h4>Key fingerprint=5C6BF59288CDD4ECA4566F994D20583410704F2E</h4>
 
     <br>
     <hr/>
@@ -37,19 +37,13 @@
     <h2>Yuriko @yurikoinaba</h2>
     <a href="keys/yuriko.asc">yuriko.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/8F94311B0D7422B170AE0CC271BA5CA94E686CF7">0x71BA5CA94E686CF7</a>
-    <h4>Key fingerprint=8F94 311B 0D74 22B1 70AE  0CC2 71BA 5CA9 4E68 6CF7</h4>
-    <hr/>
-
-    <h2>Tomas @otoumas</h2>
-    <a href="keys/tomas.asc">tomas.asc</a>
-    <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/2BBE2AA1A641F6147B58450BE3527B60DAACA1D8">0xE3527B60DAACA1D8</a>
-    <h4>Key fingerprint=2BBE 2AA1 A641 F614 7B58 450B E352 7B60 DAAC A1D8</h4>
+    <h4>Key fingerprint=8F94311B0D7422B170AE0CC271BA5CA94E686CF7</h4>
     <hr/>
 
     <h2>Jofra Montesdeoca @jmontesdeocanuez</h2>
     <a href="keys/jofra.asc">jofra.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/A95931C7C7196D9ECDC30B43EF67355CFA1D24F9">0xEF67355CFA1D24F9</a>
-    <h4>Key fingerprint=A959 31C7 C719 6D9E CDC3  0B43 EF67 355C FA1D 24F9</h4>
+    <h4>Key fingerprint=A95931C7C7196D9ECDC30B43EF67355CFA1D24F9</h4>
     <hr/>
 
     <h2>Andrea Carbone @acarbone</h2>
@@ -61,37 +55,37 @@
     <h2>TonyBo Bello @devopsbo3</h2>
     <a href="keys/tonybo.asc">tonybo.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/638FEDFD3D63342020F79E54653956A919AECFA4">0x653956A919AECFA4</a>
-    <h4>Key fingerprint=638F EDFD 3D63 3420 20F7 9E54 6539 56A9 19AE CFA4</h4>
+    <h4>Key fingerprint=638FEDFD3D63342020F79E54653956A919AECFA4</h4>
     <hr/>
 
     <h2>Christian Bonacore @cbonaco1</h2>
     <a href="keys/christian.asc">christian.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/61C8BF3DE88A2B341442045CAAE0CCCC860D4A0B">0xAAE0CCCC860D4A0B</a>
-    <h4>Key fingerprint=61C8 BF3D E88A 2B34 1442  045C AAE0 CCCC 860D 4A0B</h4>
+    <h4>Key fingerprint=61C8BF3DE88A2B341442045CAAE0CCCC860D4A0B</h4>
     <hr/>
     
     <h2>Rodrigo Doria Medina @rdoria1</h2>
     <a href="keys/rodrigo.asc">rodrigo.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/D79E76AB1B26366665DEEA845F2695F7A6F0B490">0x5F2695F7A6F0B490</a>
-    <h4>Key fingerprint=D79E 76AB 1B26 3666 65DE  EA84 5F26 95F7 A6F0 B490</h4>
+    <h4>Key fingerprint=D79E76AB1B26366665DEEA845F2695F7A6F0B490</h4>
     <hr/>
         
     <h2>Daniele Rogora @drgora</h2>
     <a href="keys/drgora.asc">drgora.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/661F6FC64773A0F47936625FD3A22623FF9B9F11">0xD3A22623FF9B9F11</a>
-    <h4>Key fingerprint=661F 6FC6 4773 A0F4 7936 625F D3A2 2623 FF9B 9F11</h4>
+    <h4>Key fingerprint=661F6FC64773A0F47936625FD3A22623FF9B9F11</h4>
     <hr />
     
     <h2>Giacomo Pirinoli @JackPiri</h2>
     <a href="keys/jackpiri.asc">jackpiri.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/B9618A4CF8AD40C57CE5F5D40B1D16372001D213">0x0B1D16372001D213</a>
-    <h4>Key fingerprint=B961 8A4C F8AD 40C5 7CE5 F5D4 0B1D 1637 2001 D213</h4>
+    <h4>Key fingerprint=B9618A4CF8AD40C57CE5F5D40B1D16372001D213</h4>
     <hr />
 
     <h2>Alberto Sala @alsala</h2>
     <a href="keys/alsala.asc">alsala.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/9C56E9D0C4B47AE266466B68026DF8A70A1548AB">0x026DF8A70A1548AB</a>
-    <h4>Key fingerprint=9C56 E9D0 C4B4 7AE2 6646 6B68 026D F8A7 0A15 48AB</h4>
+    <h4>Key fingerprint=9C56E9D0C4B47AE266466B68026DF8A70A1548AB</h4>
     <hr/>
    
     <h2>Yuri Sibirski @ysibirski</h2>
@@ -103,19 +97,19 @@
     <h2>Davide Banfi @davehorizen</h2>
     <a href="keys/davide.asc">davide.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/0301F4AE0D45C7B0340E38854AB1D49ECB9B69ED">0x4AB1D49ECB9B69ED</a>
-    <h4>Key fingerprint=0301 F4AE 0D45 C7B0 340E  3885 4AB1 D49E CB9B 69ED</h4>
+    <h4>Key fingerprint=0301F4AE0D45C7B0340E38854AB1D49ECB9B69ED</h4>
     <hr/>
 
     <h2>Santiago García @santigamo</h2>
     <a href="keys/santigamo.asc">santigamo.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/7CBF829D5928739C80FB9688FF62004A7A254584">0xFF62004A7A254584</a>
-    <h4>Key fingerprint=7CBF 829D 5928 739C 80FB  9688 FF62 004A 7A25 4584</h4>
+    <h4>Key fingerprint=7CBF829D5928739C80FB9688FF62004A7A254584</h4>
     <hr/>
 
     <h2>Daniele Di Benedetto @DanieleDiBenedetto</h2>
     <a href="keys/DanieleDiBenedetto.asc">DanieleDiBenedetto.asc</a>
     <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/36583F30BE88F97A4BC312D5E3BCCBAB6ABE6160">0xE3BCCBAB6ABE6160</a>
-    <h4>Key fingerprint=3658 3F30 BE88 F97A 4BC3  12D5 E3BC CBAB 6ABE 6160</h4>
+    <h4>Key fingerprint=36583F30BE88F97A4BC312D5E3BCCBAB6ABE6160</h4>
     <hr/>
 
 </body>


### PR DESCRIPTION
This is required for VAULT initialize check if we want to support more than keys.opengpg.org server. For example look at andreas key from MIT that we can not grep for gpg key fingerprint in the url